### PR TITLE
Make role work with chroot images

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 # tasks file for ansible-role-dell
 
- - include_tasks: redhat.yml
-   when: ansible_system_vendor == "Dell Inc." and ansible_os_family == "RedHat" and install_dell_dsu
+- include_tasks: redhat.yml
+  when:
+    - ansible_connection != 'chroot'
+    - ansible_system_vendor == "Dell Inc."
+    - ansible_os_family == "RedHat"
+    - install_dell_dsu


### PR DESCRIPTION
Ansible 2.8 made ansible_system_vendor unavailable for chroot images,
hence it needs to be guarded by an additional test. Also, split up the
conditional logic on separate lines.