### PR TITLE
Disable vil7 only if dell_omreport is set

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -60,4 +60,6 @@
                regexp="^.*vil7=dsm_sm_psrvil$"
    notify:
     - restart_dell_services
-   when: dell_disable_vil7
+   when:
+     - dell_disable_vil7
+     - dell_omreport


### PR DESCRIPTION
If omreport isn't installed, this command fails as the config file
isn't found.