### PR TITLE
Allow installing DSU without idracadm

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,12 +2,14 @@
 # defaults file for ansible-role-dell
 # set to false to not install anything
 install_dell_dsu: True
-
-dell_packages:
- - "srvadmin-idracadm7"
- - "openssl-devel"
+dell_dsu_packages:
  - "dell-system-update"
  - "net-tools"
+
+dell_install_idracadm: True
+dell_idracadm_packages:
+  - "srvadmin-idracadm7"
+  - "openssl-devel"
 
 # If True install packages so one can run check_openmanage
 # http://folk.uio.no/trondham/software/check_openmanage.html

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -30,14 +30,22 @@
  - name: install Dell DSU Key
    rpm_key: key=http://linux.dell.com/repo/hardware/dsu/public.key state=present
 
- - name: install packages
-   yum: pkg={{ item }}
-   with_items: "{{ dell_packages }}"
-   when: dell_packages.0 != ""
+ - name: install DSU packages
+   package:
+     name: "{{ dell_dsu_packages }}"
+     state: present
+   when: install_dell_dsu
+
+ - name: install idracadm packages
+   package:
+     name: "{{ dell_idracadm_packages }}"
+     state: present
+   when: dell_install_idracadm
 
  - name: install omreport packages
-   yum: pkg={{ item }}
-   with_items: "{{ dell_omreport_packages }}"
+   package:
+     name: "{{ dell_omreport_packages }}"
+     state: present
    when: dell_omreport_packages.0 != "" and dell_omreport
    register: reg_installed_omreport
 


### PR DESCRIPTION
To save space on nodes without local drives, allow installing DSU
without having to also install idracadm.

Also, install packages with the ansible package module, and use
package lists directly instead of the deprecated with_items looping.